### PR TITLE
fix location of scripts, cleanups

### DIFF
--- a/audio_plugins/build-plugins.sh
+++ b/audio_plugins/build-plugins.sh
@@ -29,12 +29,11 @@ all=0
 projucer=0
 projuce=0
 
-HERE=$(cd $(dirname $(which $0));pwd)
-cd "${HERE}"
+HERE=$(cd $(dirname $0) && pwd)
 
 # check SDKs
 ok=0
-SDKs=$(cd ${HERE}/../SDKs;pwd)
+SDKs=$(cd ${HERE}/../SDKs && pwd)
 [ -e "${SDKs}/modules" ] \
 && [ -e "${SDKs}/Spatial_Audio_Framework" ] \
 && [ -e "${SDKs}/VST2_SDK" ] && ok=1
@@ -44,11 +43,9 @@ if [ $ok == 0 ]; then
 fi
 
 # location of plugin binaries
-binaries=$(cd ${HERE}/../lib;pwd)
+binaries=$(cd ${HERE}/../lib && pwd)
 # create if missing
 mkdir -p "${binaries}"
-
-from="${HERE}"
 
 i=$#
 while [ $i -gt 0 ]; do
@@ -110,6 +107,8 @@ if [ ${info} -gt 0 ]; then
         get_info ${jucer}
     done <<< "$(find ${from} -type f -name "*.jucer")"
 fi
+
+[ -z ${from+x} ] && from="${HERE}"
 
 # opening Projucer editor
 [ ${projucer} -gt 0 ] && find "${from}" -type f -name "*.jucer" \

--- a/audio_plugins/build-projucer.sh
+++ b/audio_plugins/build-projucer.sh
@@ -29,8 +29,8 @@ usage() {
 }
 
 # find the SDKs directory
-HERE=$(cd $(dirname $(which $0));pwd)
-SDKs=$(cd ${HERE}/../SDKs;pwd)
+HERE=$(cd $(dirname $0) && pwd)
+SDKs=$(cd ${HERE}/../SDKs && pwd)
 
 list_git_tags() {
     git ls-remote -t ${git_url_base}.git | sed 's|.*/\(.*\)$|\1|' \
@@ -47,7 +47,6 @@ check_tag () {
     done <<< """master
     $(list_git_tags)"""
 }
-
 
 get_projucer_folder () {
     version=$1
@@ -101,7 +100,6 @@ activate_version () {
     fi
     validate_link modules
 }
-
 
 build () {
     version=$(check_tag ${1})


### PR DESCRIPTION
A fatal bug was fixed in the assignation of the "HERE" variable. Now using "&&" between steps. Assign "from" variable only if not provided.