### PR TITLE
6DoFconv: fix tvconv_setTargetPosition() argument order

### DIFF
--- a/audio_plugins/_SPARTA_6DoFconv_/src/PluginProcessor.cpp
+++ b/audio_plugins/_SPARTA_6DoFconv_/src/PluginProcessor.cpp
@@ -209,7 +209,7 @@ void PluginProcessor::setParameter (int index, float newValue)
         (tvconv_getMaxDimension(hTVCnv, index) - tvconv_getMinDimension(hTVCnv, index)) +
         tvconv_getMinDimension(hTVCnv, index);
         if (newValueScaled != tvconv_getTargetPosition(hTVCnv, index)){
-            tvconv_setTargetPosition(hTVCnv, index, newValueScaled);
+            tvconv_setTargetPosition(hTVCnv, newValueScaled, index);
             refreshWindow = true;
         }
     }
@@ -219,7 +219,7 @@ void PluginProcessor::setParameterRaw(int index, float newValue)
 {
     if (index < 3) {
         if (newValue != tvconv_getTargetPosition(hTVCnv, index)) {
-            tvconv_setTargetPosition(hTVCnv, index, newValue);
+            tvconv_setTargetPosition(hTVCnv, newValue, index);
             refreshWindow = true;
         }
     }


### PR DESCRIPTION
hi,

the 6DoFconv plugin contains two calls to `tvconv_setTargetPosition()` with the `position` and `dim` arguments backwards, causing crashes and/or other incorrect behavior. this patch fixes that.