### PR TITLE
Fix changing Binauraliser(NF) OSC port

### DIFF
--- a/audio_plugins/_SPARTA_binauraliser_/src/PluginEditor.cpp
+++ b/audio_plugins/_SPARTA_binauraliser_/src/PluginEditor.cpp
@@ -1134,6 +1134,10 @@ void PluginEditor::timerCallback(int timerID)
                 repaint(0,0,getWidth(),32);
             }
 
+            /* check if OSC port has changed */
+            if (hVst->getOscPortID() != te_oscport->getText().getIntValue())
+                hVst->setOscPortID(te_oscport->getText().getIntValue());
+
             break;
     }
 }

--- a/audio_plugins/_SPARTA_binauraliser_nf_/src/PluginEditor.cpp
+++ b/audio_plugins/_SPARTA_binauraliser_nf_/src/PluginEditor.cpp
@@ -1144,6 +1144,10 @@ void PluginEditor::timerCallback(int timerID)
                 repaint(0,0,getWidth(),32);
             }
 
+            /* check if OSC port has changed */
+            if (hVst->getOscPortID() != te_oscport->getText().getIntValue())
+                hVst->setOscPortID(te_oscport->getText().getIntValue());
+
             break;
     }
 }


### PR DESCRIPTION
Changing the OSC port was broken with the Binauraliser and BinauraliserNF plugins. Only the default port (9000) was opened and the port field would reset back to default when reopening the GUI.

I copied the logic from 6DoFConv, AmbiBIN & Rotator, where the OSC port is pushed to `PluginProcessor` in `timerCallback`. That seemed to do the trick.

I observed a similar issue with COMPASS Binaural-VR, but I guess the source isn't up anywhere?