### PR TITLE
Fix 6DoFconv SOFA error label being slow to update

### DIFF
--- a/audio_plugins/_SPARTA_6DoFconv_/src/PluginEditor.h
+++ b/audio_plugins/_SPARTA_6DoFconv_/src/PluginEditor.h
@@ -50,7 +50,6 @@ private:
 
     /* sofa loading */
     std::unique_ptr<juce::FilenameComponent> fileComp;
-    SAF_TVCONV_ERROR_CODES tvConvError;
 
     /* sofa file loading */
      void filenameComponentChanged (FilenameComponent*) override  {
@@ -78,6 +77,7 @@ private:
     std::unique_ptr<juce::Label> label_filterfs;
     std::unique_ptr<juce::Label> label_NOutputs;
     std::unique_ptr<juce::Label> label_nIRpositions;
+    std::unique_ptr<juce::Label> label_sofaErrorState;
     std::unique_ptr<juce::Slider> SL_source_y;
     std::unique_ptr<juce::Slider> SL_source_z;
     std::unique_ptr<juce::Slider> SL_source_x;


### PR DESCRIPTION
In SPARTA 6DoFconv, the text at the top that says "SOFA file not initialized" / "SOFA file loaded" / etc. felt laggy. It would often show the previous text and not update immediately when a new SOFA file was loaded.

![](https://github.com/user-attachments/assets/b91e1d42-1643-4017-b053-6de5cc4792f2)

The issue seems to have been that the bounds of this `repaint` call were wrong:

https://github.com/leomccormack/SPARTA/blob/168a574d7e57b760157a7f43a0851be4c4f076f1/audio_plugins/_SPARTA_6DoFconv_/src/PluginEditor.cpp#L1109-L1110

Maybe the position of the text changed at some point, but this wasn't updated. Keeping the bounds in sync manually is tedious, so I did this:

- Make the text a proper label, so it is repainted automatically on change
- Refactor converting the error code to a text into its own function